### PR TITLE
Remove note about draft state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If an issue doesn't receive any updates within 14 days when more feedback was re
 ## Pull Requests
 
 * You can open a PR any time, but you should open it as a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready for review or merging yet. Be sure to include a title and clear description, and as much relevant information as possible.
-* If you deem the PR ready change the status to "Ready for review" and request a review from the vfsStream team. You can also request a review while a PR is still in draft state to receive comments and feedback, but it can't be approved as long as it is in draft state.
+* If you deem the PR ready, change the status to "Ready for review" and request a review from the vfsStream team. You can also request a review while a PR is still in draft state to receive comments and feedback, but it can't be approved as long as it is in draft state.
 * A PR most likely adds a change which is relevant for the changelog. The review should ensure that an appropriate addition for the changelog is included.
 * A PR can be merged when at least two members of the team approve it and no other member rejects it. If the author is part of the team, it can't be approved by the author, two other team members need to give approval.
 * Anybody on the team can do the merge once approval and no rejection was given, this includes the author of the PR when it is a team member.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-**Note: this is currently in draft mode and not finalised yet.**
-
 # How to contribute
 
 Thank you for your interest in contributing. We appreciate you taking the time to make this project better.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,14 @@ Ensure the bug was not already reported by searching on GitHub under Issues.
 
 If you're unable to find an open issue addressing the problem, open a new one. Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
 
-If an issue doesn't receive any updates within 14 days when more feedback was requested the issue will be closed, except a clear date of a next step is given. However, closed issues can be reopened any time.
+If an issue doesn't receive any updates within 14 days when more feedback was requested the issue will be closed, unless a clear date of a next step is given. However, closed issues can be reopened any time.
 
 ## Pull Requests
 
 * You can open a PR any time, but you should open it as a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready for review or merging yet. Be sure to include a title and clear description, and as much relevant information as possible.
-* If you deem the PR ready change the status to “Ready for review” and request a review from the vfsStream team. You can also request a review while a PR is still in draft state to receive comments and feedback, but it can't be approved as long as it is in draft state.
+* If you deem the PR ready change the status to "Ready for review" and request a review from the vfsStream team. You can also request a review while a PR is still in draft state to receive comments and feedback, but it can't be approved as long as it is in draft state.
 * A PR most likely adds a change which is relevant for the changelog. The review should ensure that an appropriate addition for the changelog is included.
-* A PR can be merged when at least two members of the team approves it and no other member rejects it. If the author is part of the team it can't be approved by the author, two other team member need to give approval.
-* Everybody in the team can do the merge once approval and no rejection was given, this includes the author of the PR when it is a team member.
-* Sometimes a merge can be the sensible thing to do even if one or more of the checks (coverage, tests) fails. However, in such cases there should be a comment with a rationale of why the merge was done anyway.
-* Pull requests which have seen no activity within 14 days will be closed, except a clear date of a next step is given. Closed pull requests can be reopened any time if work resumes.
+* A PR can be merged when at least two members of the team approve it and no other member rejects it. If the author is part of the team, it can't be approved by the author, two other team members need to give approval.
+* Anybody on the team can do the merge once approval and no rejection was given, this includes the author of the PR when it is a team member.
+* Sometimes a merge can be the sensible thing to do even if one or more of the checks (coverage, tests) fails. However, in such cases, there should be a comment with a rationale of why the merge was done anyway.
+* Pull requests which have seen no activity within 14 days will be closed, unless a clear date of a next step is given. Closed pull requests can be reopened any time if work resumes.


### PR DESCRIPTION
As no other suggestions were made, I suggest to remove the draft state and make our contributing guidelines official.